### PR TITLE
Sequentialize deployments

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -41,6 +41,10 @@ jobs:
         run: make push
         env:
           WONDERLAND_GITHUB_TOKEN: ${{ secrets.WONDERLAND_GITHUB_TOKEN }}
+      - name: Turnstyle
+        uses: softprops/turnstyle@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy
         run: make deploy
         env:


### PR DESCRIPTION
This avoids races when quickly merging pull requests which might end up
with an older version deployed